### PR TITLE
Move `h1` outside of `ul`

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,12 +1,12 @@
-import React from 'react'
-import FetchData from './Components/FetchData'
+import React from "react";
+import FetchData from "./Components/FetchData";
 
 function App() {
   return (
- <>
- <FetchData/>
- </>
-  )
+    <>
+      <FetchData />
+    </>
+  );
 }
 
-export default App
+export default App;

--- a/src/Components/FetchData.jsx
+++ b/src/Components/FetchData.jsx
@@ -1,13 +1,12 @@
-import React from 'react'
+import React from "react";
 
 const FetchData = () => {
   return (
     <>
-     <ul className='list_data_main'>
-        <h1 className='usefetch_heading'>Use Fetch Custom Hook</h1>
-     </ul>
+      <h1 className="usefetch_heading">Use Fetch Custom Hook</h1>
+      <ul className="list_data_main"></ul>
     </>
-  )
-}
+  );
+};
 
-export default FetchData
+export default FetchData;


### PR DESCRIPTION
`h1` is not permitted within `ul`. See
https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/ul#technical_summary

Additionally:

- semicolons were added at the end of lines;
- formatting was improved for `App.jsx`.

Closes #19 